### PR TITLE
_blink_points() now finds blinks after a long one

### DIFF
--- a/datamatrix/_datamatrix/_blinkreconstruct.py
+++ b/datamatrix/_datamatrix/_blinkreconstruct.py
@@ -57,7 +57,11 @@ def _blink_points(vtrace, vt_start, vt_end, maxdur, margin):
     # generally very long (although they can be).
     if iend - istart > maxdur:
         logger.debug('blink too long ({})'.format(iend - istart))
-        return None
+        blink_points = _blink_points(vtrace[iend:], vt_start=vt_start, vt_end=vt_end,
+                                    maxdur=maxdur, margin=margin)
+        if blink_points is not None:
+            blink_points += iend
+        return blink_points
     return np.array([istart, iend])
 
 


### PR DESCRIPTION
I have changed `_blink_points()` in order not to return `None` if the blink is too long (which means no more blinks).  Now, if the blink is too long, it searches for blinks in the remaining trace (`vtrace[iend:]`) and if it finds one, it corrects the indexes by adding the `iend`. 