### PR TITLE
Replace np.in1d with np.isin

### DIFF
--- a/datamatrix/_datamatrix/_numericcolumn.py
+++ b/datamatrix/_datamatrix/_numericcolumn.py
@@ -277,9 +277,9 @@ class NumericColumn(BaseColumn):
 
     def _merge(self, other, _rowid):
 
-        i_other = ~np.in1d(other._rowid, self._rowid) \
-            & np.in1d(other._rowid, _rowid)
-        i_self = np.in1d(self._rowid, _rowid)
+        i_other = ~np.isin(other._rowid, self._rowid) \
+            & np.isin(other._rowid, _rowid)
+        i_self = np.isin(self._rowid, _rowid)
         rowid = np.concatenate(
             (self._rowid[i_self], other._rowid[i_other]))
         seq = np.concatenate((self._seq[i_self], other._seq[i_other]))


### PR DESCRIPTION
np.in1d has been deprecated since NumPy 2.0, and was removed in 2.4. Switch to using np.isin.

I'm happy to update this to support both in1d and isin if you'd prefer to keep compatibility with previous NumPy releases.